### PR TITLE
Return whether post type or taxonomy was registered successfully 

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -25,10 +25,11 @@ abstract class PostType implements Registrable {
 	 */
 	public function register(): bool {
 		if ( ! post_type_exists( static::NAME ) ) {
-			register_post_type(
+			$post_type = register_post_type(
 				static::NAME,
 				$this->get_args()
 			);
+			return ! is_wp_error( $post_type );
 		}
 
 		return true;

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -39,10 +39,6 @@ abstract class Taxonomy implements Registrable {
 				$this->get_args()
 			);
 			return ! is_wp_error( $taxonomy );
-		} else {
-			foreach ( $this->get_object_types() as $object_type ) {
-				register_taxonomy_for_object_type( static::NAME, $object_type );
-			}
 		}
 
 		return true;

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -33,11 +33,12 @@ abstract class Taxonomy implements Registrable {
 	 */
 	public function register(): bool {
 		if ( ! taxonomy_exists( static::NAME ) ) {
-			register_taxonomy(
+			$taxonomy = register_taxonomy(
 				static::NAME,
 				$this->get_object_types(),
 				$this->get_args()
 			);
+			return ! is_wp_error( $taxonomy );
 		} else {
 			foreach ( $this->get_object_types() as $object_type ) {
 				register_taxonomy_for_object_type( static::NAME, $object_type );


### PR DESCRIPTION
I would like to remove `$object_types` from the `Taxonomy` class in future and use `register_taxonomy_for_object_type()` instead.