### PR TITLE
Use Args to populate post type/taxonomy/post meta/term meta arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-* Use [Args](https://github.com/johnbillion/args) to populate post type arguments.
+* Use [Args](https://github.com/johnbillion/args) to populate post type and taxonomy arguments.
 
 ## [0.2.1] - 2022-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* Use [Args](https://github.com/johnbillion/args) to populate post type arguments.
+
 ## [0.2.1] - 2022-03-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-* Use [Args](https://github.com/johnbillion/args) to populate post type and taxonomy arguments.
+* Use [Args](https://github.com/johnbillion/args) to populate post type, taxonomy, and meta arguments.
 
 ## [0.2.1] - 2022-03-11
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     }
   ],
   "require": {
-    "php": ">=7.4"
+    "php": ">=7.4",
+    "johnbillion/args": "^1.1"
   },
   "require-dev": {
     "szepeviktor/phpstan-wordpress": "^1.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,4 +23,8 @@
 			</property>
 		</properties>
 	</rule>
+
+	<rule ref="Squiz.Commenting.VariableComment">
+		<exclude-pattern>/src/Args/*</exclude-pattern>
+	</rule>
 </ruleset>

--- a/src/Args/HierarchicalPostTypeLabels.php
+++ b/src/Args/HierarchicalPostTypeLabels.php
@@ -40,6 +40,13 @@ class HierarchicalPostTypeLabels extends Args\Shared\Base {
 	public string $menu_name;
 
 	/**
+	 * Label for add new from admin bar.
+	 *
+	 * Default is value of `$singular_name`.
+	 */
+	public string $name_admin_bar;
+
+	/**
 	 * Short label for adding a new item.
 	 *
 	 * When internationalizing this string, please use a {@link https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context gettext context}.

--- a/src/Args/HierarchicalPostTypeLabels.php
+++ b/src/Args/HierarchicalPostTypeLabels.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * HierarchicalPostTypeLabels class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `labels` argument of `register_post_type()` function in WordPress.
+ *
+ * @since 0.3.0
+ *
+ * @link https://developer.wordpress.org/reference/functions/get_post_type_labels/
+ */
+class HierarchicalPostTypeLabels extends Args\Shared\Base {
+
+	/**
+	 * General name for the post type, usually plural.
+	 *
+	 * Default `_x( 'Pages', 'post type general name' )`.
+	 */
+	public string $name;
+
+	/**
+	 * Name for one object of this post type.
+	 *
+	 * Default `_x( 'Page', 'post type singular name' )`.
+	 */
+	public string $singular_name;
+
+	/**
+	 * Label for the menu name.
+	 *
+	 * Default is value of `$name`.
+	 */
+	public string $menu_name;
+
+	/**
+	 * Short label for adding a new item.
+	 *
+	 * When internationalizing this string, please use a {@link https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context gettext context}.
+	 *
+	 * Default `_x( 'Add New', 'page' )`.
+	 */
+	public string $add_new;
+
+	/**
+	 * Label for adding a new singular item.
+	 *
+	 * Default `__( 'Add New Page' )`.
+	 */
+	public string $add_new_item;
+
+	/**
+	 * Label for editing a singular item.
+	 *
+	 * Default `__( 'Edit Page' )`.
+	 */
+	public string $edit_item;
+
+	/**
+	 * Label for the new item page title.
+	 *
+	 * Default `__( 'New Page' )`.
+	 */
+	public string $new_item;
+
+	/**
+	 * Label for viewing a singular item.
+	 *
+	 * Default `__( 'View Page' )`.
+	 */
+	public string $view_item;
+
+	/**
+	 * Label for viewing post type archives.
+	 *
+	 * Default `__( 'View Pages' )`.
+	 */
+	public string $view_items;
+
+	/**
+	 * Label for searching plural items.
+	 *
+	 * Default `__( 'Search Pages' )`.
+	 */
+	public string $search_items;
+
+	/**
+	 * Label used when no items are found.
+	 *
+	 * Default `__( 'No pages found.' )`.
+	 */
+	public string $not_found;
+
+	/**
+	 * Label used when no items are in the Trash.
+	 *
+	 * Default `__( 'No pages found in Trash.' )`.
+	 */
+	public string $not_found_in_trash;
+
+	/**
+	 * Label used to prefix parents of hierarchical items.
+	 *
+	 * Default `__( 'Parent Page:' )`.
+	 */
+	public string $parent_item_colon;
+
+	/**
+	 * Label to signify all items in a submenu link.
+	 *
+	 * Default `__( 'All Pages' )`.
+	 */
+	public string $all_items;
+
+	/**
+	 * Label for archives in nav menus.
+	 *
+	 * Default `__( 'Page Archives' )`.
+	 */
+	public string $archives;
+
+	/**
+	 * Label for the attributes meta box.
+	 *
+	 * Default `__( 'Page Attributes' )`.
+	 */
+	public string $attributes;
+
+	/**
+	 * Label for the media frame button.
+	 *
+	 * Default `__( 'Insert into page' )`.
+	 */
+	public string $insert_into_item;
+
+	/**
+	 * Label for the media frame filter.
+	 *
+	 * Default `__( 'Uploaded to this page' )`.
+	 */
+	public string $uploaded_to_this_item;
+
+	/**
+	 * Label for the featured image meta box title.
+	 *
+	 * Default `_x( 'Featured image', 'page' )`.
+	 */
+	public string $featured_image;
+
+	/**
+	 * Label for setting the featured image.
+	 *
+	 * Default `_x( 'Set featured image', 'page' )`.
+	 */
+	public string $set_featured_image;
+
+	/**
+	 * Label for removing the featured image.
+	 *
+	 * Default `_x( 'Remove featured image', 'page' )`.
+	 */
+	public string $remove_featured_image;
+
+	/**
+	 * Label in the media frame for using a featured image.
+	 *
+	 * Default `_x( 'Use as featured image', 'page' )`.
+	 */
+	public string $use_featured_image;
+
+	/**
+	 * Label for the table views hidden heading.
+	 *
+	 * Default `__( 'Filter pages list' )`.
+	 */
+	public string $filter_items_list;
+
+	/**
+	 * Label for the date filter in list tables.
+	 *
+	 * Default `__( 'Filter by date' )`.
+	 */
+	public string $filter_by_date;
+
+	/**
+	 * Label for the table pagination hidden heading.
+	 *
+	 * Default `__( 'Pages list navigation' )`.
+	 */
+	public string $items_list_navigation;
+
+	/**
+	 * Label for the table hidden heading.
+	 *
+	 * Default `__( 'Pages list' )`.
+	 */
+	public string $items_list;
+
+	/**
+	 * Label used when an item is published.
+	 *
+	 * Default `__( 'Page published.' )`.
+	 */
+	public string $item_published;
+
+	/**
+	 * Label used when an item is published with private visibility.
+	 *
+	 * Default `__( 'Page published privately.' )`.
+	 */
+	public string $item_published_privately;
+
+	/**
+	 * Label used when an item is switched to a draft.
+	 *
+	 * Default `__( 'Page reverted to draft.' )`.
+	 */
+	public string $item_reverted_to_draft;
+
+	/**
+	 * Label used when an item is scheduled for publishing.
+	 *
+	 * Default `__( 'Page scheduled.' )`.
+	 */
+	public string $item_scheduled;
+
+	/**
+	 * Label used when an item is updated.
+	 *
+	 * Default `__( 'Page updated.' )`.
+	 */
+	public string $item_updated;
+
+	/**
+	 * Used in the block editor. Title for a navigation link block variation.
+	 *
+	 * Default `_x( 'Page Link', 'navigation link block title' )`.
+	 */
+	public string $item_link;
+
+	/**
+	 * Used in the block editor. Description for a navigation link block variation.
+	 *
+	 * Default `_x( 'A link to a page.', 'navigation link block description' )`.
+	 */
+	public string $item_link_description;
+}

--- a/src/Args/HierarchicalTaxonomyLabels.php
+++ b/src/Args/HierarchicalTaxonomyLabels.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * HierarchicalTaxonomyLabels class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `labels` argument of `register_taxonomy()` function in WordPress.
+ *
+ * @since 0.3.0
+ *
+ * @link https://developer.wordpress.org/reference/functions/get_taxonomy_labels/
+ */
+class HierarchicalTaxonomyLabels extends Args\Shared\Base {
+
+	/**
+	 * General name for the taxonomy, usually plural.
+	 *
+	 * Default `_x( 'Categories', 'taxonomy general name' )`.
+	 */
+	public string $name;
+
+	/**
+	 * Name for one object of this post type.
+	 *
+	 * Default `_x( 'Category', 'taxonomy singular name' )`.
+	 */
+	public string $singular_name;
+
+	/**
+	 * Label for the menu name.
+	 *
+	 * Default is value of `$name`.
+	 */
+	public string $menu_name;
+
+	/**
+	 * Label for searching plural items.
+	 *
+	 * Default `__( 'Search Categories' )`.
+	 */
+	public string $search_items;
+
+	/**
+	 * Label to signify all items in a submenu link.
+	 *
+	 * Default `__( 'All Categories' )`.
+	 */
+	public string $all_items;
+
+	/**
+	 * Label used for dropdown for assigning parent item.
+	 *
+	 * Default `__( 'Parent Category' )`.
+	 */
+	public string $parent_item;
+
+	/**
+	 * Label used to prefix parents of hierarchical items.
+	 *
+	 * Default `__( 'Parent Category:' )`.
+	 */
+	public string $parent_item_colon;
+
+	/**
+	 * Description for the Name field on Edit Tags screen.
+	 *
+	 * Default `__( 'The name is how it appears on your site.' )`.
+	 */
+	public string $name_field_description;
+
+	/**
+	 * Description for the Slug field on Edit Tags screen.
+	 *
+	 * Default `__( 'The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.' )`.
+	 */
+	public string $slug_field_description;
+
+	/**
+	 * Description for the Parent field on Edit Tags screen.
+	 *
+	 * Default `__( 'Assign a parent term to create a hierarchy. The term Jazz, for example, would be the parent of Bebop and Big Band.' )`.
+	 */
+	public string $parent_field_description;
+
+	/**
+	 * Description for the Description field on Edit Tags screen.
+	 *
+	 * Default `__( 'The description is not prominent by default; however, some themes may show it.' )`.
+	 */
+	public string $desc_field_description;
+
+	/**
+	 * Label for editing a singular item.
+	 *
+	 * Default `__( 'Edit Category' )`.
+	 */
+	public string $edit_item;
+
+	/**
+	 * Label for viewing a singular item.
+	 *
+	 * Default `__( 'View Category' )`.
+	 */
+	public string $view_item;
+
+	/**
+	 * Label for updating a singular item.
+	 *
+	 * Default `__( 'Update Category' )`.
+	 */
+	public string $update_item;
+
+	/**
+	 * Label for adding a new singular item.
+	 *
+	 * Default `__( 'Add New Category' )`.
+	 */
+	public string $add_new_item;
+
+	/**
+	 * Label for adding a new name of a singular item.
+	 *
+	 * Default `__( 'New Category Name' )`.
+	 */
+	public string $new_item_name;
+
+	/**
+	 * Label used when no items are found.
+	 *
+	 * Default `__( 'No categories found.' )`.
+	 */
+	public string $not_found;
+
+	/**
+	 * Label used in the posts and media list tables when no items
+	 * are assigned to an object.
+	 *
+	 * Default `__( 'No categories' )`.
+	 */
+	public string $no_terms;
+
+	/**
+	 * Label for the term filter in list tables.
+	 *
+	 * Default `__( 'Filter by category' )`.
+	 */
+	public string $filter_by_item;
+
+	/**
+	 * Label for the table pagination hidden heading.
+	 *
+	 * Default `__( 'Categories list navigation' )`.
+	 */
+	public string $items_list_navigation;
+
+	/**
+	 * Label for the table hidden heading.
+	 *
+	 * Default `__( 'Categories list' )`.
+	 */
+	public string $items_list;
+
+	/**
+	 * Label for tab heading when selecting from the most used terms.
+	 *
+	 * Default `_x( 'Most Used', 'categories' )`.
+	 */
+	public string $most_used;
+
+	/**
+	 * Label displayed after a term has been updated.
+	 *
+	 * Default `__( '&larr; Go to Categories' )`.
+	 */
+	public string $back_to_items;
+
+	/**
+	 * Used in the block editor. Title for a navigation link block variation.
+	 *
+	 * Default `_x( 'Category Link', 'navigation link block title' )`.
+	 */
+	public string $item_link;
+
+	/**
+	 * Used in the block editor. Description for a navigation link block variation.
+	 *
+	 * Default `_x( 'A link to a category.', 'navigation link block description' )`.
+	 */
+	public string $item_link_description;
+}

--- a/src/Args/NonHierarchicalPostTypeLabels.php
+++ b/src/Args/NonHierarchicalPostTypeLabels.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * NonHierarchicalPostTypeLabels class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `labels` argument of `register_post_type()` function in WordPress.
+ *
+ * @since 0.3.0
+ *
+ * @link https://developer.wordpress.org/reference/functions/get_post_type_labels/
+ */
+class NonHierarchicalPostTypeLabels extends Args\Shared\Base {
+
+	/**
+	 * General name for the post type, usually plural.
+	 *
+	 * Default `_x( 'Posts', 'post type general name' )`.
+	 */
+	public string $name;
+
+	/**
+	 * Name for one object of this post type.
+	 *
+	 * Default `_x( 'Post', 'post type singular name' )`.
+	 */
+	public string $singular_name;
+
+	/**
+	 * Label for the menu name.
+	 *
+	 * Default is value of `$name`.
+	 */
+	public string $menu_name;
+
+	/**
+	 * Short label for adding a new item.
+	 *
+	 * When internationalizing this string, please use a {@link https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context gettext context}.
+	 *
+	 * Default `_x( 'Add New', 'post' )`.
+	 */
+	public string $add_new;
+
+	/**
+	 * Label for adding a new singular item.
+	 *
+	 * Default `__( 'Add New Post' )`.
+	 */
+	public string $add_new_item;
+
+	/**
+	 * Label for editing a singular item.
+	 *
+	 * Default `__( 'Edit Post' )`.
+	 */
+	public string $edit_item;
+
+	/**
+	 * Label for the new item page title.
+	 *
+	 * Default `__( 'New Post' )`.
+	 */
+	public string $new_item;
+
+	/**
+	 * Label for viewing a singular item.
+	 *
+	 * Default `__( 'View Post' )`.
+	 */
+	public string $view_item;
+
+	/**
+	 * Label for viewing post type archives.
+	 *
+	 * Default `__( 'View Posts' )`.
+	 */
+	public string $view_items;
+
+	/**
+	 * Label for searching plural items.
+	 *
+	 * Default `__( 'Search Posts' )`.
+	 */
+	public string $search_items;
+
+	/**
+	 * Label used when no items are found.
+	 *
+	 * Default `__( 'No posts found.' )`.
+	 */
+	public string $not_found;
+
+	/**
+	 * Label used when no items are in the Trash.
+	 *
+	 * Default `__( 'No posts found in Trash.' )`.
+	 */
+	public string $not_found_in_trash;
+
+	/**
+	 * Label to signify all items in a submenu link.
+	 *
+	 * Default `__( 'All Posts' )`.
+	 */
+	public string $all_items;
+
+	/**
+	 * Label for archives in nav menus.
+	 *
+	 * Default `__( 'Post Archives' )`.
+	 */
+	public string $archives;
+
+	/**
+	 * Label for the attributes meta box.
+	 *
+	 * Default `__( 'Post Attributes' )`.
+	 */
+	public string $attributes;
+
+	/**
+	 * Label for the media frame button.
+	 *
+	 * Default `__( 'Insert into post' )`.
+	 */
+	public string $insert_into_item;
+
+	/**
+	 * Label for the media frame filter.
+	 *
+	 * Default `__( 'Uploaded to this post' )`.
+	 */
+	public string $uploaded_to_this_item;
+
+	/**
+	 * Label for the featured image meta box title.
+	 *
+	 * Default `_x( 'Featured image', 'post' )`.
+	 */
+	public string $featured_image;
+
+	/**
+	 * Label for setting the featured image.
+	 *
+	 * Default `_x( 'Set featured image', 'post' )`.
+	 */
+	public string $set_featured_image;
+
+	/**
+	 * Label for removing the featured image.
+	 *
+	 * Default `_x( 'Remove featured image', 'post' )`.
+	 */
+	public string $remove_featured_image;
+
+	/**
+	 * Label in the media frame for using a featured image.
+	 *
+	 * Default `_x( 'Use as featured image', 'post' )`.
+	 */
+	public string $use_featured_image;
+
+	/**
+	 * Label for the table views hidden heading.
+	 *
+	 * Default `__( 'Filter posts list' )`.
+	 */
+	public string $filter_items_list;
+
+	/**
+	 * Label for the date filter in list tables.
+	 *
+	 * Default `__( 'Filter by date' )`.
+	 */
+	public string $filter_by_date;
+
+	/**
+	 * Label for the table pagination hidden heading.
+	 *
+	 * Default `__( 'Posts list navigation' )`.
+	 */
+	public string $items_list_navigation;
+
+	/**
+	 * Label for the table hidden heading.
+	 *
+	 * Default `__( 'Posts list' )`.
+	 */
+	public string $items_list;
+
+	/**
+	 * Label used when an item is published.
+	 *
+	 * Default `__( 'Post published.' )`.
+	 */
+	public string $item_published;
+
+	/**
+	 * Label used when an item is published with private visibility.
+	 *
+	 * Default `__( 'Post published privately.' )`.
+	 */
+	public string $item_published_privately;
+
+	/**
+	 * Label used when an item is switched to a draft.
+	 *
+	 * Default `__( 'Post reverted to draft.' )`.
+	 */
+	public string $item_reverted_to_draft;
+
+	/**
+	 * Label used when an item is scheduled for publishing.
+	 *
+	 * Default `__( 'Post scheduled.' )`.
+	 */
+	public string $item_scheduled;
+
+	/**
+	 * Label used when an item is updated.
+	 *
+	 * Default `__( 'Post updated.' )`.
+	 */
+	public string $item_updated;
+
+	/**
+	 * Used in the block editor. Title for a navigation link block variation.
+	 *
+	 * Default `_x( 'Post Link', 'navigation link block title' )`.
+	 */
+	public string $item_link;
+
+	/**
+	 * Used in the block editor. Description for a navigation link block variation.
+	 *
+	 * Default `_x( 'A link to a post.', 'navigation link block description' )`.
+	 */
+	public string $item_link_description;
+}

--- a/src/Args/NonHierarchicalPostTypeLabels.php
+++ b/src/Args/NonHierarchicalPostTypeLabels.php
@@ -40,6 +40,13 @@ class NonHierarchicalPostTypeLabels extends Args\Shared\Base {
 	public string $menu_name;
 
 	/**
+	 * Label for add new from admin bar.
+	 *
+	 * Default is value of `$singular_name`.
+	 */
+	public string $name_admin_bar;
+
+	/**
 	 * Short label for adding a new item.
 	 *
 	 * When internationalizing this string, please use a {@link https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context gettext context}.

--- a/src/Args/NonHierarchicalTaxonomyLabels.php
+++ b/src/Args/NonHierarchicalTaxonomyLabels.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * NonHierarchicalTaxonomyLabels class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `labels` argument of `register_taxonomy()` function in WordPress.
+ *
+ * @since 0.3.0
+ *
+ * @link https://developer.wordpress.org/reference/functions/get_taxonomy_labels/
+ */
+class NonHierarchicalTaxonomyLabels extends Args\Shared\Base {
+
+	/**
+	 * General name for the taxonomy, usually plural.
+	 *
+	 * Default `_x( 'Tags', 'taxonomy general name' )`.
+	 */
+	public string $name;
+
+	/**
+	 * Name for one object of this post type.
+	 *
+	 * Default `_x( 'Tag', 'taxonomy singular name' )`.
+	 */
+	public string $singular_name;
+
+	/**
+	 * Label for the menu name.
+	 *
+	 * Default is value of `$name`.
+	 */
+	public string $menu_name;
+
+	/**
+	 * Label for searching plural items.
+	 *
+	 * Default `__( 'Search Tags' )`.
+	 */
+	public string $search_items;
+
+	/**
+	 * Label to signify all items in a submenu link.
+	 *
+	 * Default `__( 'All Tags' )`.
+	 */
+	public string $all_items;
+
+	/**
+	 * Description for the Name field on Edit Tags screen.
+	 *
+	 * Default `__( 'The name is how it appears on your site.' )`.
+	 */
+	public string $name_field_description;
+
+	/**
+	 * Description for the Slug field on Edit Tags screen.
+	 *
+	 * Default `__( 'The &#8220;slug&#8221; is the URL-friendly version of the name. It is usually all lowercase and contains only letters, numbers, and hyphens.' )`.
+	 */
+	public string $slug_field_description;
+
+	/**
+	 * Description for the Description field on Edit Tags screen.
+	 *
+	 * Default `__( 'The description is not prominent by default; however, some themes may show it.' )`.
+	 */
+	public string $desc_field_description;
+
+	/**
+	 * Label for editing a singular item.
+	 *
+	 * Default `__( 'Edit Tag' )`.
+	 */
+	public string $edit_item;
+
+	/**
+	 * Label for viewing a singular item.
+	 *
+	 * Default `__( 'View Tag' )`.
+	 */
+	public string $view_item;
+
+	/**
+	 * Label for updating a singular item.
+	 *
+	 * Default `__( 'Update Tag' )`.
+	 */
+	public string $update_item;
+
+	/**
+	 * Label for adding a new singular item.
+	 *
+	 * Default `__( 'Add New Tag' )`.
+	 */
+	public string $add_new_item;
+
+	/**
+	 * Label for adding a new name of a singular item.
+	 *
+	 * Default `__( 'New Tag Name' )`.
+	 */
+	public string $new_item_name;
+
+	/**
+	 * Label used in the meta box for adding terms to an object.
+	 *
+	 * Default `__( 'Separate tags with commas' )`.
+	 */
+	public string $separate_items_with_commas;
+
+	/**
+	 * Label used in the meta box when JavaScript is disabled.
+	 *
+	 * Default `__( 'Add or remove tags' )`.
+	 */
+	public string $add_or_remove_items;
+
+	/**
+	 * Label used in the meta box for adding terms to an object.
+	 *
+	 * Default `__( 'Choose from the most used tags' )`.
+	 */
+	public string $choose_from_most_used;
+
+	/**
+	 * Label used when no items are found.
+	 *
+	 * Default `__( 'No tags found.' )`.
+	 */
+	public string $not_found;
+
+	/**
+	 * Label used in the posts and media list tables when no items
+	 * are assigned to an object.
+	 *
+	 * Default `__( 'No tags' )`.
+	 */
+	public string $no_terms;
+
+	/**
+	 * Label for the table pagination hidden heading.
+	 *
+	 * Default `__( 'Tags list navigation' )`.
+	 */
+	public string $items_list_navigation;
+
+	/**
+	 * Label for the table hidden heading.
+	 *
+	 * Default `__( 'Tags list' )`.
+	 */
+	public string $items_list;
+
+	/**
+	 * Label for tab heading when selecting from the most used terms.
+	 *
+	 * Default `_x( 'Most Used', 'tags' )`.
+	 */
+	public string $most_used;
+
+	/**
+	 * Label displayed after a term has been updated.
+	 *
+	 * Default `__( '&larr; Go to Tags' )`.
+	 */
+	public string $back_to_items;
+
+	/**
+	 * Used in the block editor. Title for a navigation link block variation.
+	 *
+	 * Default `_x( 'Tag Link', 'navigation link block title' )`.
+	 */
+	public string $item_link;
+
+	/**
+	 * Used in the block editor. Description for a navigation link block variation.
+	 *
+	 * Default `_x( 'A link to a category.', 'navigation link block description' )`.
+	 */
+	public string $item_link_description;
+}

--- a/src/Args/PostMeta.php
+++ b/src/Args/PostMeta.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * PostMeta class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `register_post_meta()` function in WordPress.
+ *
+ * @since 0.3.0
+ */
+class PostMeta extends Args\register_post_meta {
+}

--- a/src/Args/PostType.php
+++ b/src/Args/PostType.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * PostType class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `register_post_type()` function in WordPress.
+ *
+ * @since 0.3.0
+ */
+class PostType extends Args\register_post_type {
+}

--- a/src/Args/Taxonomy.php
+++ b/src/Args/Taxonomy.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Taxonomy class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `register_taxonomy()` function in WordPress.
+ *
+ * @since 0.3.0
+ */
+class Taxonomy extends Args\register_taxonomy {
+}

--- a/src/Args/TermMeta.php
+++ b/src/Args/TermMeta.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * TermMeta class.
+ *
+ * @since 0.3.0
+ */
+
+namespace Required\Common\Args;
+
+use Args;
+
+/**
+ * Arguments for the `register_term_meta()` function in WordPress.
+ *
+ * @since 0.3.0
+ */
+class TermMeta extends Args\register_term_meta {
+}

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -7,6 +7,7 @@
 
 namespace Required\Common;
 
+use Required\Common\Args\PostMeta as PostMetaArgs;
 use Required\Common\Contracts\Registrable;
 
 /**
@@ -80,7 +81,7 @@ abstract class PostMeta implements Registrable {
 	 * @return string Type of the data.
 	 */
 	protected function type(): string {
-		return 'string';
+		return PostMetaArgs::TYPE_STRING;
 	}
 
 	/**

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -7,6 +7,7 @@
 
 namespace Required\Common;
 
+use Required\Common\Args\PostType as PostTypeArgs;
 use Required\Common\Contracts\Registrable;
 
 /**
@@ -29,7 +30,7 @@ abstract class PostType implements Registrable {
 		if ( ! post_type_exists( static::NAME ) ) {
 			$post_type = register_post_type(
 				static::NAME,
-				$this->get_args()
+				$this->get_args()->toArray()
 			);
 			return ! is_wp_error( $post_type );
 		}
@@ -42,7 +43,7 @@ abstract class PostType implements Registrable {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return array Post type arguments.
+	 * @return \Required\Common\Args\PostType Post type arguments.
 	 */
-	abstract protected function get_args(): array;
+	abstract protected function get_args(): PostTypeArgs;
 }

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -7,6 +7,7 @@
 
 namespace Required\Common;
 
+use Required\Common\Args\Taxonomy as TaxonomyArgs;
 use Required\Common\Contracts\Registrable;
 
 /**
@@ -39,7 +40,7 @@ abstract class Taxonomy implements Registrable {
 			$taxonomy = register_taxonomy(
 				static::NAME,
 				$this->get_object_types(),
-				$this->get_args()
+				$this->get_args()->toArray()
 			);
 			return ! is_wp_error( $taxonomy );
 		}
@@ -74,7 +75,7 @@ abstract class Taxonomy implements Registrable {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return array Taxonomy arguments.
+	 * @return \Required\Common\Args\Taxonomy Taxonomy arguments.
 	 */
-	abstract protected function get_args();
+	abstract protected function get_args(): TaxonomyArgs;
 }

--- a/src/TermMeta.php
+++ b/src/TermMeta.php
@@ -7,6 +7,7 @@
 
 namespace Required\Common;
 
+use Required\Common\Args\TermMeta as TermMetaArgs;
 use Required\Common\Contracts\Registrable;
 
 /**
@@ -80,7 +81,7 @@ abstract class TermMeta implements Registrable {
 	 * @return string Type of the data.
 	 */
 	protected function type(): string {
-		return 'string';
+		return TermMetaArgs::TYPE_STRING;
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/johnbillion/args.

This change should make it easier to register custom post types and taxonomies by getting autocompletion for all the available arguments.

Example:
<img width="852" alt="Bildschirmfoto 2022-03-11 um 15 57 51" src="https://user-images.githubusercontent.com/617637/157896469-6c077f71-6645-44c6-b740-d2d5cc2c2d31.png">
https://github.com/wearerequired/ringier-advertising-ad-manager/blob/222098ebed5b36ece07825bd5e836f26d5092e6a/inc/PostType/AdFormat.php#L23-L45


I'm using custom classes as a layer here to be able to change/extend the arguments in the future if necessary.